### PR TITLE
Fixed: remove wrong quote in value

### DIFF
--- a/gulp-html-partial.js
+++ b/gulp-html-partial.js
@@ -62,6 +62,14 @@ module.exports = (function () {
             const match = regexp.exec(tag);
 
             if (match) {
+
+                // Fixed: when value length is 1, regex add double quote before value
+                // When: <partial src="..." foo="1"></partial> >>> match[2] === '"1';
+                // We remove quoute '"1' >>> '1'
+                if (match[2].charAt(0) === '"') {
+                    match[2] = match[2].substr(1);
+                }
+
                 attributes.push({
                     key: match[1],
                     value: match[2]


### PR DESCRIPTION
When have this code:

```html
<partial src="..." foo="1"></partial>
```

const match is:

```js
match=['foo="1"', 'foo', '"1']
```

We remove match[2] first quote:

```js
match=['foo="1"', 'foo', '1']
```